### PR TITLE
Add map with directions to get_directions page.

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,9 +1,8 @@
 class WelcomeController < ApplicationController
 
 	def get_directions
-		#api calls for getting directions goes here
 		@destination_lon, @destination_lat = get_destination(params[:lon], params[:lat], params[:distance])
-		@directions = HTTParty.get("https://api.mapbox.com/v4/directions/mapbox.walking/#{params[:lon]},#{params[:lat]};#{@destination_lon},#{@destination_lat}.json?access_token=pk.eyJ1IjoicmFuZG9td2FsayIsImEiOiJjaWw0Y3B5dzEwMjl1dGhseXcyOWh5NGJpIn0.ZKl7LVbPulKaAqQjbsMJfQ")
+		# @directions = HTTParty.get("https://api.mapbox.com/v4/directions/mapbox.walking/#{params[:lon]},#{params[:lat]};#{@destination_lon},#{@destination_lat}.json?access_token=pk.eyJ1IjoicmFuZG9td2FsayIsImEiOiJjaWw0Y3B5dzEwMjl1dGhseXcyOWh5NGJpIn0.ZKl7LVbPulKaAqQjbsMJfQ")
 	end
 
 	private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 
   <style>
     body { margin:0; padding:0; }
-    #map { width:80%; height:400px; }
+    #map { width:80%; height:550px; }
   </style>
 
   <%= csrf_meta_tags %>

--- a/app/views/welcome/get_directions.html.erb
+++ b/app/views/welcome/get_directions.html.erb
@@ -1,7 +1,26 @@
 <br>
-<h1><%= params[:distance] %> Miles of running! Go you!</h1>
-<h1><%= params[:lon] %></h1>
-<h1><%= params[:lat] %></h1>
-MAP AND DIRECTIONS GO HERE
-<h1><%= @destination_lat %></h1>
-<h1><%= @destination_lon %></h1>
+<h1><%= params[:distance] %> miles of running! Go you!</h1>
+
+<script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v1.0.0/mapbox-gl-directions.js'></script>
+<link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v1.0.0/mapbox-gl-directions.css' type='text/css' />
+
+<div id='map'></div>
+
+<script>
+mapboxgl.accessToken = 'pk.eyJ1IjoicmFuZG9td2FsayIsImEiOiJjaWw0Y3B5dzEwMjl1dGhseXcyOWh5NGJpIn0.ZKl7LVbPulKaAqQjbsMJfQ';
+var map = new mapboxgl.Map({
+  container: 'map',
+  style: 'mapbox://styles/mapbox/streets-v8',
+  center: [<%= params[:lon] %>, <%= params[:lat] %>],
+  zoom: 13
+});
+
+var directions = new mapboxgl.Directions({
+  profile: 'walking'
+});
+
+directions.setOrigin([<%= params[:lon] %>, <%= params[:lat] %>]);
+directions.setDestination([<%= @destination_lon %>, <%= @destination_lat %>]);
+
+map.addControl(directions);
+</script>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,12 +1,20 @@
 <h1>Welcome to RandomWalk</h1>
 
-<button onclick="getLocation()" style="font-size: 21pt">Get Current Location</button>
+<!-- <button onclick="getLocation()" style="font-size: 21pt">Get Current Location</button> -->
 
-<p id="location-coords"></p>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  getLocation();
+}, false);
+</script>
+
+<p id="location-coords">Getting current location...</p>
+
 <script>
 var myPosition;
 var map;
 var x = document.getElementById("location-coords");
+
 function getLocation() {
   if (navigator.geolocation) {
     var spinner = new Spinner().spin(x);
@@ -16,7 +24,12 @@ function getLocation() {
       x.innerHTML = "Geolocation is not supported by this browser.";
   }
 }
+
 function showPosition(position) {
+  document.getElementById("form-lon").value = position.coords.longitude;
+  document.getElementById("form-lat").value = position.coords.latitude;
+  document.getElementById("form-submit").disabled = false;
+
   mapboxgl.accessToken = 'pk.eyJ1IjoicmFuZG9td2FsayIsImEiOiJjaWw0Y3B5dzEwMjl1dGhseXcyOWh5NGJpIn0.ZKl7LVbPulKaAqQjbsMJfQ';
   map = new mapboxgl.Map({
     container: 'map', // container id
@@ -92,10 +105,38 @@ function showPosition(position) {
 
 <div id='map'></div>
 
+<style>
+input[type=text]
+{
+    font-size: 24px;
+    font-weight: bold;
+    font-family: Helvetica;
+    width: 300px;
+    padding: 20px;
+    text-align: center;
+}
+input[type=submit]
+{
+    font-size: 24px;
+    font-weight: bold;
+    font-family: Helvetica;
+    background-color: #00CD00;
+    color: #ffffff;
+    width: 300px;
+    height: 100px;
+}
+</style>
+
 <form action="/get_directions">
 	How many miles do you want to run?<br>
 	<input type="text" name="distance"><br>
-	<input type="hidden" name="lon" value="-122.393448"> <!-- update these to pass the current longitude -->
-	<input type="hidden" name="lat" value="37.781031"> <!-- update these to pass the current latitude -->
-	<input type="submit" value="Run!">
+	<input id="form-lon" type="hidden" name="lon">
+	<input id="form-lat" type="hidden" name="lat">
+	<input id="form-submit" type="submit" disabled value="Run!" style="font-size: 21pt">
 </form>
+
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>


### PR DESCRIPTION
| [Trello card](https://trello.com/c/zv0fQFf2/6-show-the-generated-path-on-a-map) |
| --- |
- Automatically get user's current location on the index page.
- Disable form submit button until location has loaded.
- Set hidden form values to user's longitude and latitude.
- Increase map height to 550px.
- Use Mapbox GL Directions
  - https://github.com/mapbox/mapbox-gl-directions
  - Mapbox GL Directions is a client-side plugin.
  - Remove unnecessary server-side API call.
